### PR TITLE
Add 'withTitle' to Marker

### DIFF
--- a/src/GoogleMaps/Marker.elm
+++ b/src/GoogleMaps/Marker.elm
@@ -2,6 +2,7 @@ module GoogleMaps.Marker exposing
     ( Marker, Latitude, Longitude, init
     , withIcon, withDraggableMode
     , onClick
+    , withTitle
     )
 
 {-| This module allows you to create markers to be used along with GoogleMaps.Map
@@ -74,6 +75,13 @@ onClick msg marker =
 withIcon : String -> Marker msg -> Marker msg
 withIcon icon marker =
     IMarker.withIcon icon marker
+
+
+{-| Sets an on hover title for the marker
+-}
+withTitle : String -> Marker msg -> Marker msg
+withTitle title marker =
+    IMarker.withTitle title marker
 
 
 {-| Makes the marker draggable

--- a/src/GoogleMaps/Marker.elm
+++ b/src/GoogleMaps/Marker.elm
@@ -1,8 +1,7 @@
 module GoogleMaps.Marker exposing
     ( Marker, Latitude, Longitude, init
-    , withIcon, withDraggableMode
+    , withIcon, withDraggableMode, withTitle
     , onClick
-    , withTitle
     )
 
 {-| This module allows you to create markers to be used along with GoogleMaps.Map
@@ -26,7 +25,7 @@ module GoogleMaps.Marker exposing
 
 # Modifiers
 
-@docs withIcon, withDraggableMode
+@docs withIcon, withDraggableMode, withTitle
 
 
 # Events

--- a/src/Internals/Marker.elm
+++ b/src/Internals/Marker.elm
@@ -5,6 +5,7 @@ module Internals.Marker exposing
     , toHtml
     , withDraggableMode
     , withIcon
+    , withTitle
     )
 
 import Html exposing (Html, node)
@@ -24,6 +25,7 @@ type alias Options msg =
     , longitude : Float
     , icon : Maybe String
     , isDraggable : Bool
+    , title : Maybe String
     }
 
 
@@ -35,6 +37,7 @@ init latitude longitude =
         , longitude = longitude
         , icon = Nothing
         , isDraggable = False
+        , title = Nothing
         }
 
 
@@ -53,6 +56,11 @@ onClick msg (Marker marker) =
     Marker { marker | onClick = Just msg }
 
 
+withTitle : String -> Marker msg -> Marker msg
+withTitle title (Marker marker) =
+    Marker { marker | title = Just title }
+
+
 toHtml : Marker msg -> Html msg
 toHtml (Marker marker) =
     let
@@ -63,6 +71,7 @@ toHtml (Marker marker) =
             ]
                 |> addIf marker.isDraggable (attribute "draggable" "true")
                 |> maybeAdd (\icon -> [ attribute "icon" icon ]) marker.icon
+                |> maybeAdd (\title -> [ attribute "title" title ]) marker.title
                 |> maybeAdd
                     (\msg ->
                         [ on "google-map-marker-click" (Decode.succeed msg)


### PR DESCRIPTION
Small little contribution to allow setting the `title` of a marker.

I'd also like to ask if anyone has attempted to wrap the `google-map-directions` stuff.  I'm currently attempting to port an old project from Vanilla JS Google maps to Elm and will need that as well.  Has any one tried it?  Is it worth looking at trying to add?