### PR TITLE
LMO-2162 | Info Window on mouseover/mouseout

### DIFF
--- a/src/GoogleMaps/Marker.elm
+++ b/src/GoogleMaps/Marker.elm
@@ -2,7 +2,7 @@ module GoogleMaps.Marker exposing
     ( Marker, Latitude, Longitude, init, Animation
     , withIcon, withDraggableMode, withTitle, withAnimation, withInfoWindow
     , bounce, drop
-    , onClick
+    , onClick, withInfoWindowOnMouseOver
     )
 
 {-| This module allows you to create markers to be used along with GoogleMaps.Map
@@ -36,7 +36,7 @@ module GoogleMaps.Marker exposing
 
 # Events
 
-@docs onClick
+@docs onClick, withInfoWindowOnMouseOver
 
 -}
 
@@ -121,6 +121,13 @@ When empty, disables the info window.
 withInfoWindow : List (Html msg) -> Marker msg -> Marker msg
 withInfoWindow infoWindow marker =
     IMarker.withInfoWindow infoWindow marker
+
+
+{-| Allows to enter/leave a Info Window specified in [`withInfoWindow`](#withInfoWindow)
+-}
+withInfoWindowOnMouseOver : Marker msg -> Marker msg
+withInfoWindowOnMouseOver marker =
+    IMarker.withInfoWindowOnMouseOver True marker
 
 
 {-| Get Bounce animation

--- a/src/Internals/Marker.elm
+++ b/src/Internals/Marker.elm
@@ -8,6 +8,7 @@ module Internals.Marker exposing
     , withDraggableMode
     , withIcon
     , withInfoWindow
+    , withInfoWindowOnMouseOver
     , withTitle
     )
 
@@ -36,6 +37,7 @@ type alias Options msg =
     , title : Maybe String
     , animation : Maybe Animation
     , infoWindow : List (Html msg)
+    , infoOnMouse : Maybe String
     }
 
 
@@ -50,6 +52,7 @@ init latitude longitude =
         , title = Nothing
         , animation = Nothing
         , infoWindow = []
+        , infoOnMouse = Nothing
         }
 
 
@@ -83,6 +86,19 @@ withInfoWindow infoWindow (Marker options) =
     Marker { options | infoWindow = infoWindow }
 
 
+withInfoWindowOnMouseOver : Bool -> Marker msg -> Marker msg
+withInfoWindowOnMouseOver value (Marker options) =
+    let
+        valueStr =
+            if value then
+                "true"
+
+            else
+                "false"
+    in
+    Marker { options | infoOnMouse = Just valueStr }
+
+
 animationToAttribute : Animation -> String
 animationToAttribute a =
     case a of
@@ -111,6 +127,7 @@ toHtml (Marker options) =
                 |> addIf options.isDraggable (attribute "draggable" "true")
                 |> maybeAdd (\icon -> [ attribute "icon" icon ]) options.icon
                 |> maybeAdd (\title -> [ attribute "title" title ]) options.title
+                |> maybeAdd (\infoOnMouse -> [ attribute "info-on-mouse" infoOnMouse ]) options.infoOnMouse
                 |> maybeAdd
                     (\msg ->
                         [ on "google-map-marker-click" (Decode.succeed msg)


### PR DESCRIPTION
## What?

- Allow opening-closing the Info Window without using clicking anything.

## Why?

Enhance UX for LMO.

## Jira

[LMO-2162](https://paacklogistics.atlassian.net/browse/LMO-2162).

## Blocked by

- https://github.com/PaackEng/google-map/pull/7